### PR TITLE
 ビルド時のInvalid URLエラーを修正

### DIFF
--- a/app/_action/getOgp.ts
+++ b/app/_action/getOgp.ts
@@ -11,48 +11,59 @@ export type OgpResult = {
 };
 
 export async function getOgp(url: string): Promise<OgpResult> {
-  const domain = new URL(url).hostname;
-  const defaultFavicon = new URL('/favicon.ico', url).toString();
-
-  // YouTube/Udemy用の特別なハンドリング
-  if (domain.includes('youtube.com') || domain.includes('youtu.be')) {
-    return handleYouTubeOgp(url, domain);
-  }
-  
-  if (domain.includes('udemy.com')) {
-    return handleUdemyOgp(url, domain);
-  }
-
   try {
-    const { result } = await ogs({ url });
-    const title = (result.ogTitle as string) ?? '';
-    const image =
-      Array.isArray(result.ogImage) && result.ogImage.length > 0
-        ? (result.ogImage[0].url as string)
-        : typeof result.ogImage === 'object' && 'url' in result.ogImage
-          ? (result.ogImage.url as string)
-          : '';
-    let favicon = defaultFavicon;
-    if ('favicon' in result) {
-      const raw =
-        Array.isArray(result.favicon) && result.favicon.length > 0
-          ? (result.favicon[0] as string)
-          : typeof result.favicon === 'string'
-            ? result.favicon
-            : null;
-      if (raw) {
-        favicon = raw.startsWith('http') ? raw : new URL(raw, url).toString();
-      }
+    const domain = new URL(url).hostname;
+    const defaultFavicon = new URL('/favicon.ico', url).toString();
+
+    // YouTube/Udemy用の特別なハンドリング
+    if (domain.includes('youtube.com') || domain.includes('youtu.be')) {
+      return handleYouTubeOgp(url, domain);
+    }
+    
+    if (domain.includes('udemy.com')) {
+      return handleUdemyOgp(url, domain);
     }
 
-    return { title, image, domain, url, favicon };
+    try {
+      const { result } = await ogs({ url });
+      const title = (result.ogTitle as string) ?? '';
+      const image =
+        Array.isArray(result.ogImage) && result.ogImage.length > 0
+          ? (result.ogImage[0].url as string)
+          : typeof result.ogImage === 'object' && 'url' in result.ogImage
+            ? (result.ogImage.url as string)
+            : '';
+      let favicon = defaultFavicon;
+      if ('favicon' in result) {
+        const raw =
+          Array.isArray(result.favicon) && result.favicon.length > 0
+            ? (result.favicon[0] as string)
+            : typeof result.favicon === 'string'
+              ? result.favicon
+              : null;
+        if (raw) {
+          favicon = raw.startsWith('http') ? raw : new URL(raw, url).toString();
+        }
+      }
+
+      return { title, image, domain, url, favicon };
+    } catch (error) {
+      return {
+        title: '',
+        image: '',
+        domain,
+        url,
+        favicon: defaultFavicon,
+      };
+    }
   } catch (error) {
+    // Invalid URL の場合は空のデータを返す
     return {
       title: '',
       image: '',
-      domain,
+      domain: '',
       url,
-      favicon: defaultFavicon,
+      favicon: '',
     };
   }
 }

--- a/app/article/[articleId]/page.tsx
+++ b/app/article/[articleId]/page.tsx
@@ -23,10 +23,7 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
     title: article.title,
     description: articleSite.description,
     openGraph: {
-      url: new URL(
-        `/article/${params.articleId}`,
-        process.env.SERVER_DOMAIN || '',
-      ).toString(),
+      url: `${process.env.SERVER_DOMAIN || 'http://localhost:3000'}/article/${params.articleId}`,
       siteName: 'クリエイターさかのウェブサイト',
       images: [
         {
@@ -34,7 +31,7 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
           height: article.eyecatch?.height ? article.eyecatch?.height : '800',
           url: article.eyecatch?.url
             ? article.eyecatch.url
-            : new URL(dummy.src, process.env.SERVER_DOMAIN || '').toString(), // URLを生成
+            : `${process.env.SERVER_DOMAIN || 'http://localhost:3000'}${dummy.src}`, // URLを生成
         },
       ],
       locale: 'jp',

--- a/data/site.ts
+++ b/data/site.ts
@@ -16,7 +16,7 @@ export const site: SiteConfig = {
     'クリエイターさかのウェブサイトです。趣味、ウェブ技術についてまとめています。',
   titleTemplate: '%s | saka.dev',
   defaultOpenGraph: {
-    url: new URL(topLink.href, process.env.SERVER_DOMAIN || '').toString(), // 完全なURLを生成
+    url: new URL(topLink.href, process.env.SERVER_DOMAIN || 'http://localhost:3000').toString(), // 完全なURLを生成
   },
 };
 
@@ -24,7 +24,7 @@ export const profileSite: SiteInfo = {
   title: 'Profile',
   description: 'クリエイターさかのプロフィールです。',
   openGraph: {
-    url: new URL(pageLinks[0].href, process.env.SERVER_DOMAIN || '').toString(), // 完全なURLを生成
+    url: new URL(pageLinks[0].href, process.env.SERVER_DOMAIN || 'http://localhost:3000').toString(), // 完全なURLを生成
   },
 };
 
@@ -32,7 +32,7 @@ export const blogSite: SiteInfo = {
   title: 'Blog',
   description: 'すべての記事一覧です。',
   openGraph: {
-    url: new URL(pageLinks[1].href, process.env.SERVER_DOMAIN || '').toString(), // 完全なURLを生成
+    url: new URL(pageLinks[1].href, process.env.SERVER_DOMAIN || 'http://localhost:3000').toString(), // 完全なURLを生成
   },
 };
 

--- a/features/article/conponents/LinkCard/LinkCard.tsx
+++ b/features/article/conponents/LinkCard/LinkCard.tsx
@@ -17,18 +17,23 @@ const LinkCard = async ({
 
   // 環境変数SERVER_DOMAINと同じドメインの場合は空の結果を返す
   if (serverDomain) {
-    // www.の有無を無視して比較
-    const normalizedDomain = ogp.domain.replace(/^www\./, '');
-    const normalizedServerDomain = new URL(serverDomain).hostname.replace(
-      /^www\./,
-      '',
-    );
+    try {
+      // www.の有無を無視して比較
+      const normalizedDomain = ogp.domain.replace(/^www\./, '');
+      const normalizedServerDomain = new URL(serverDomain).hostname.replace(
+        /^www\./,
+        '',
+      );
 
-    // ドメインが一致する場合、相対パスの形式に変更
-    if (normalizedDomain === normalizedServerDomain) {
-      const parsed = new URL(ogp.url);
-      ogp.url = parsed.pathname + parsed.search + parsed.hash;
-      isDomainFlag = true;
+      // ドメインが一致する場合、相対パスの形式に変更
+      if (normalizedDomain === normalizedServerDomain) {
+        const parsed = new URL(ogp.url);
+        ogp.url = parsed.pathname + parsed.search + parsed.hash;
+        isDomainFlag = true;
+      }
+    } catch (error) {
+      // Invalid URL の場合は何もしない
+      console.warn('Invalid SERVER_DOMAIN URL:', serverDomain);
     }
   }
 


### PR DESCRIPTION
  ビルド時のInvalid URLエラーを修正

  - getOgp.tsで無効なURL入力に対するエラーハンドリングを追加
  - 記事メタデータでnew URL()を文字列結合に置き換え
  - site.tsで空のSERVER_DOMAINに対してlocalhostフォールバックを提供
  - LinkCardコンポーネントでURL解析のtry-catchブロックを追加

  SERVER_DOMAIN環境変数が設定されていない場合のビルド失敗を解決。

  🤖 Generated with https://claude.ai/code

  Co-Authored-By: Claude mailto:noreply@anthropic.com