### PR TITLE
fix: framer-motion を v11 → v12 にアップグレード（React 19 対応）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@next/third-parties": "^16.0.0",
         "cheerio": "^1.0.0-rc.12",
         "firebase": "^10.13.0",
-        "framer-motion": "^11.3.0",
+        "framer-motion": "^12.36.0",
         "html-react-parser": "^5.2.17",
         "microcms-js-sdk": "^3.1.1",
         "next": "^16.0.0",
@@ -4772,17 +4772,19 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.11.10",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.10.tgz",
-      "integrity": "sha512-061Bt1jL/vIm+diYIiA4dP/Yld7vD47ROextS7ESBW5hr4wQFhxB5D5T5zAc3c/5me3cOa+iO5LqhA38WDln/A==",
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.36.0.tgz",
+      "integrity": "sha512-4PqYHAT7gev0ke0wos+PyrcFxI0HScjm3asgU8nSYa8YzJFuwgIvdj3/s3ZaxLq0bUSboIn19A2WS/MHwLCvfw==",
       "license": "MIT",
       "dependencies": {
+        "motion-dom": "^12.36.0",
+        "motion-utils": "^12.36.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/is-prop-valid": {
@@ -6341,6 +6343,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.36.0.tgz",
+      "integrity": "sha512-Ep1pq8P88rGJ75om8lTCA13zqd7ywPGwCqwuWwin6BKc0hMLkVfcS6qKlRqEo2+t0DwoUcgGJfXwaiFn4AOcQA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@next/third-parties": "^16.0.0",
     "cheerio": "^1.0.0-rc.12",
     "firebase": "^10.13.0",
-    "framer-motion": "^11.3.0",
+    "framer-motion": "^12.36.0",
     "html-react-parser": "^5.2.17",
     "microcms-js-sdk": "^3.1.1",
     "next": "^16.0.0",


### PR DESCRIPTION
## Summary

- `framer-motion` を `^11.3.0` → `^12.36.0` にアップグレード
- framer-motion@11 は `react@^18.0.0` をピア依存として要求しており、React 19 環境の Vercel で `npm install` がエラーになっていた
- v12 は React 19 に正式対応しているため解消

## 背景

PR #22（Next.js 15→16 / React 18→19 アップグレード）を main にマージ後、Vercel デプロイが 0ms でエラー終了。ローカルでは既存の `node_modules` があるためビルドが通るが、Vercel はクリーンインストールのため失敗していた。

## Test plan

- [x] `npm run build` 成功（全23ページ生成）
- [ ] Vercel デプロイ成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)